### PR TITLE
Fixed initialize() method for context map

### DIFF
--- a/di-lite.js
+++ b/di-lite.js
@@ -53,8 +53,10 @@ di = {
 
         ctx.initialize = function () {
             for (var name in ctx.map) {
-                var entry = ctx.entry(name);
-                ctx.ready(ctx.inject(name, ctx.get(name), entry.dependencies()));
+                if (ctx.map.hasOwnProperty(name)) {
+                    var entry = ctx.entry(name);
+                    ctx.ready(ctx.inject(name, ctx.get(name), entry.dependencies()));
+                }
             }
         };
 


### PR DESCRIPTION
If Object.prototype contains some additional properties, initialization fails.
Example:

``` javascript
Object.prototype.foo = function() {}


function Bar() {
 // bar constructor
}

var DiContainer = di.createContext();

DiContainer.register('bar', Bar);

DiContainer.initialize();

```
